### PR TITLE
Enable dynamic email subject generation

### DIFF
--- a/packages/email-plugin/src/handler/event-handler.ts
+++ b/packages/email-plugin/src/handler/event-handler.ts
@@ -14,6 +14,7 @@ import {
     LoadDataFn,
     SetAttachmentsFn,
     SetOptionalAddressFieldsFn,
+    SetSubjectFn,
     SetTemplateVarsFn,
 } from '../types';
 
@@ -140,7 +141,7 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
     private setOptionalAddressFieldsFn?: SetOptionalAddressFieldsFn<Event>;
     private filterFns: Array<(event: Event) => boolean> = [];
     private configurations: EmailTemplateConfig[] = [];
-    private defaultSubject: string;
+    private defaultSubject: string | SetSubjectFn<Event>;
     private from: string;
     private optionalAddressFields: {
         cc?: string;
@@ -214,7 +215,7 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
      * Sets the default subject of the email. The subject string may use Handlebars variables defined by the
      * setTemplateVars() method.
      */
-    setSubject(defaultSubject: string): EmailEventHandler<T, Event> {
+    setSubject(defaultSubject: string | SetSubjectFn<Event>): EmailEventHandler<T, Event> {
         this.defaultSubject = defaultSubject;
         return this;
     }
@@ -370,7 +371,11 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
         const { ctx } = event;
         const languageCode = this.setLanguageCodeFn?.(event) || ctx.languageCode;
         const configuration = this.getBestConfiguration(ctx.channel.code, languageCode);
-        const subject = configuration ? configuration.subject : this.defaultSubject;
+        const subject = configuration
+            ? configuration.subject
+            : typeof this.defaultSubject === 'function'
+            ? await this.defaultSubject(event, injector)
+            : this.defaultSubject;
         if (subject == null) {
             throw new Error(
                 `No subject field has been defined. ` +

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -378,6 +378,16 @@ export type SetTemplateVarsFn<Event> = (
 
 /**
  * @description
+ * A function used to define the subject of the email.
+ *
+ * @docsCategory core plugins/EmailPlugin
+ * @docsPage Email Plugin Types
+ * @since x.x.x
+ */
+export type SetSubjectFn<Event> = (event: Event, injector: Injector) => string | Promise<string>;
+
+/**
+ * @description
  * A function used to define attachments to be sent with the email.
  * See https://nodemailer.com/message/attachments/ for more information about
  * how attachments work in Nodemailer.


### PR DESCRIPTION
# Description

This PR introduces support for dynamic email subjects in the Email Plugin, allowing subjects to be generated based on the event context and other dynamic data. Previously, email subjects were limited to static strings, which restricted flexibility.

The changes include:
*   Adding a new `SetSubjectFn` type in `packages/email-plugin/src/types.ts`.
*   Modifying the `setSubject` method in `EmailEventHandler` (`packages/email-plugin/src/handler/event-handler.ts`) to accept either a string or a `SetSubjectFn`.
*   Updating the `handle` method in `EmailEventHandler` to execute the `SetSubjectFn` if provided, using its return value as the email subject.

# Breaking changes

No breaking changes are introduced with this PR. The existing functionality for static subjects remains supported.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

---
<a href="https://cursor.com/background-agent?bcId=bc-2d0c1145-dca1-420d-9657-c7c76a068110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d0c1145-dca1-420d-9657-c7c76a068110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

